### PR TITLE
MLPAB-2708 - associate alb with shared waf

### DIFF
--- a/terraform/environment/region/modules/app/waf.tf
+++ b/terraform/environment/region/modules/app/waf.tf
@@ -1,0 +1,11 @@
+resource "aws_wafv2_web_acl_association" "shared_waf" {
+  resource_arn = aws_lb.app.arn
+  web_acl_arn  = data.aws_wafv2_web_acl.shared.arn
+  provider     = aws.region
+}
+
+data "aws_wafv2_web_acl" "shared" {
+  name     = "shared-${data.aws_default_tags.current.tags.account-name}-web-acl"
+  scope    = "REGIONAL"
+  provider = aws.region
+}

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -33,7 +33,7 @@ locals {
   mandatory_moj_tags = {
     business-unit    = "OPG"
     application      = "opg-mrlpa-mainstream-content"
-    environment-name = local.environment_name
+    environment-name = "${local.environment_name}-mrlpa-mc"
     owner            = "OPG Webops: opgteam+opg-mrlpa-mainstream-content@digital.justice.gov.uk"
     is-production    = local.environment.is_production
     runbook          = "https://github.com/ministryofjustice/opg-make-and-register-lpa-mainstream-content"


### PR DESCRIPTION
# Purpose

protect app from common exploits

Fixes MLPAB-2708

## Approach

- associate ALB with shared WAF
- add `mrlpa-mc` to environment name to make resources easier to identify
