### PR TITLE
MLPAB-3088 - upgrade git version in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS fetched-repo
+FROM node:20-alpine@sha256:d3507a213936fe4ef54760a186e113db5188472d9efdf491686bd94580a1c1e8 AS fetched-repo
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ RUN apk add --no-cache git=2.49.0-r0
 ADD https://api.github.com/repos/gaynorc75/register-lpa-prototype/git/refs/heads/main version.json
 RUN git clone -b main https://github.com/gaynorc75/register-lpa-prototype.git
 
-FROM node:20-alpine AS build
+FROM node:20-alpine@sha256:d3507a213936fe4ef54760a186e113db5188472d9efdf491686bd94580a1c1e8 AS build
 
 RUN addgroup -g 1017 -S appgroup \
   && adduser -u 1017 -S appuser -G appgroup

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:20-alpine AS fetched-repo
 
 WORKDIR /app
 
-RUN apk add --no-cache git=2.47.2-r0
+RUN apk add --no-cache git=2.49.0-r0
 ADD https://api.github.com/repos/gaynorc75/register-lpa-prototype/git/refs/heads/main version.json
 RUN git clone -b main https://github.com/gaynorc75/register-lpa-prototype.git
 


### PR DESCRIPTION
# Purpose

Path to live failed because specified version of git requested to install is no longer available

Fixes MLPAB-3088

## Approach

- update version of git to install